### PR TITLE
Solve annotation problem of decorator

### DIFF
--- a/classopt/__init__.py
+++ b/classopt/__init__.py
@@ -1,3 +1,5 @@
 from .decorator import classopt
 from .inheritance import ClassOpt
 from .config import config
+
+__all__ = ["classopt", "ClassOpt", "config"]

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -1,9 +1,34 @@
 import typing
+from typing import TYPE_CHECKING, overload
 from argparse import ArgumentParser
 from dataclasses import dataclass
 
+if TYPE_CHECKING:
+    from typing import Literal, Callable, TypeVar, Type
+    _C = TypeVar("_C")
+    
+    class _ClassOptMeta(type[_C]):
+        @classmethod
+        def from_args(cls) -> Type[_C]:
+            ...
 
-def classopt(cls=None, default_long: bool = False, default_short: bool = False):
+@overload
+def classopt(
+    cls: "Type[_C]",
+    default_long: bool = False,
+    default_short: bool = False,
+) -> "_ClassOptMeta[_C]":
+    ...
+
+@overload
+def classopt(
+    cls: "Literal[None]" = None,
+    default_long: bool = False,
+    default_short: bool = False,
+) -> "Callable[[Type[_C]], _ClassOptMeta[_C]]":
+    ...
+
+def classopt(cls=None, default_long=False, default_short=False):
     def wrap(cls):
         return _process_class(cls, default_long, default_short)
 

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     
     class _ClassOptMeta(type[_C]):
         @classmethod
-        def from_args(cls) -> Type[_C]:
+        def from_args(cls) -> _C:
             ...
 
 @overload

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -123,6 +123,7 @@ class TestClassOpt(unittest.TestCase):
 
 
 def set_args(*args):
+    del_args()  # otherwise tests fail with e.g. "pytest -s"
     for arg in args:
         sys.argv.append(arg)
 


### PR DESCRIPTION
This PR adds typing stuff to make decorated class "understandable" by type checkers.

The screenshot below is how test code looks like in my vscode.

![image](https://user-images.githubusercontent.com/40591297/179404055-6435de22-f563-49b0-8cf3-a8ac35a24081.png)
