### PR TITLE
Use Generic type to avoid misannotation

### DIFF
--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -15,10 +15,10 @@ if TYPE_CHECKING:
 
 @overload
 def classopt(
-    cls: Type[_C],
+    cls: "Type[_C]",
     default_long: bool = False,
     default_short: bool = False,
-) -> Union[Type[_C], Type[_ClassOptGeneric[_C]]]:
+) -> "Union[Type[_C], Type[_ClassOptGeneric[_C]]]":
     ...
 
 @overload
@@ -26,7 +26,7 @@ def classopt(
     cls: "Literal[None]" = None,
     default_long: bool = False,
     default_short: bool = False,
-) -> Callable[[Type[_C]], Union[Type[_C], Type[_ClassOptGeneric[_C]]]]:
+) -> "Callable[[Type[_C]], Union[Type[_C], Type[_ClassOptGeneric[_C]]]]":
     ...
 
 def classopt(cls=None, default_long=False, default_short=False):

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -4,20 +4,21 @@ from argparse import ArgumentParser
 from dataclasses import dataclass
 
 if TYPE_CHECKING:
-    from typing import Literal, Callable, TypeVar, Type
+    from typing import Literal, Callable, TypeVar, Type, Union, Generic
     _C = TypeVar("_C")
+    _T = TypeVar("_T")
     
-    class _ClassOptMeta(type[_C]):
+    class _ClassOptGeneric(Generic[_T]):
         @classmethod
-        def from_args(cls) -> _C:
+        def from_args(cls) -> _T:
             ...
 
 @overload
 def classopt(
-    cls: "Type[_C]",
+    cls: Type[_C],
     default_long: bool = False,
     default_short: bool = False,
-) -> "_ClassOptMeta[_C]":
+) -> Union[Type[_C], Type[_ClassOptGeneric[_C]]]:
     ...
 
 @overload
@@ -25,7 +26,7 @@ def classopt(
     cls: "Literal[None]" = None,
     default_long: bool = False,
     default_short: bool = False,
-) -> "Callable[[Type[_C]], _ClassOptMeta[_C]]":
+) -> Callable[[Type[_C]], Union[Type[_C], Type[_ClassOptGeneric[_C]]]]:
     ...
 
 def classopt(cls=None, default_long=False, default_short=False):


### PR DESCRIPTION
Fixes #5 

This PR is just a workaround and is not a complete solution.

In both cases below

```python
arg = Args.from_args()
arg: Args = Args.from_args()
```

attributes of `arg` can be correctly infered, but the type of `arg` is `Any | Args` instead of `Args`.