### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04", "macos-12", "windows-2022"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -28,4 +28,4 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run test
-        run: portry run pytest
+        run: poetry run pytest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,31 @@
+name: Unit test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04", "macos-12", "windows-2022"]
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install library
+        run: poetry install --no-interaction
+
+      - name: Run test
+        run: portry run pytest

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -5,13 +5,15 @@ from dataclasses import dataclass
 
 if TYPE_CHECKING:
     from typing import Literal, Callable, TypeVar, Type, Union, Generic
+
     _C = TypeVar("_C")
     _T = TypeVar("_T")
-    
+
     class _ClassOptGeneric(Generic[_T]):
         @classmethod
         def from_args(cls) -> _T:
             ...
+
 
 @overload
 def classopt(
@@ -21,6 +23,7 @@ def classopt(
 ) -> "Union[Type[_C], Type[_ClassOptGeneric[_C]]]":
     ...
 
+
 @overload
 def classopt(
     cls: "Literal[None]" = None,
@@ -28,6 +31,7 @@ def classopt(
     default_short: bool = False,
 ) -> "Callable[[Type[_C]], Union[Type[_C], Type[_ClassOptGeneric[_C]]]]":
     ...
+
 
 def classopt(cls=None, default_long=False, default_short=False):
     def wrap(cls):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,3 +1,4 @@
+from typing import List
 import unittest
 import sys
 
@@ -30,7 +31,7 @@ class TestClassOpt(unittest.TestCase):
             short_arg2: str = config(long=True, short="-x")
             default_int: int = config(long=True, default=3)
             store_true: bool = config(long=True, action="store_true")
-            nargs: list = config(long=True, nargs="+", type=int)
+            nargs: List[int] = config(long=True, nargs="+", type=int)
 
         set_args(
             "--long_arg",
@@ -90,11 +91,9 @@ class TestClassOpt(unittest.TestCase):
         del_args()
 
     def test_generic_alias(self):
-        from typing import List
-
         @classopt(default_long=True)
         class Opt:
-            list_a: list[int] = config(nargs="+")
+            list_a: List[int] = config(nargs="+")
             list_b: List[str] = config(nargs="*")
 
         set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")
@@ -109,7 +108,7 @@ class TestClassOpt(unittest.TestCase):
     def test_default_value(self):
         @classopt(default_long=True)
         class Opt:
-            numbers: list[int]
+            numbers: List[int]
             flag: bool
 
         set_args("--numbers", "1", "2", "3", "--flag")

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,6 +1,8 @@
-from typing import List
-import unittest
 import sys
+import unittest
+from typing import List
+
+import pytest
 
 from classopt import classopt, config
 
@@ -94,6 +96,25 @@ class TestClassOpt(unittest.TestCase):
         @classopt(default_long=True)
         class Opt:
             list_a: List[int] = config(nargs="+")
+            list_b: List[str] = config(nargs="*")
+
+        set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")
+
+        opt = Opt.from_args()
+
+        assert opt.list_a == [3, 2, 1]
+        assert opt.list_b == ["hello", "world"]
+
+        del_args()
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="These version does not support `list` type with subscription.",
+    )
+    def test_generic_alias_for_python3_9_or_later(self):
+        @classopt(default_long=True)
+        class Opt:
+            list_a: list[int] = config(nargs="+")
             list_b: List[str] = config(nargs="*")
 
         set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,3 +1,4 @@
+from typing import List
 import unittest
 import sys
 
@@ -28,7 +29,7 @@ class TestClassOpt(unittest.TestCase):
             short_arg2: str = config(long=True, short="-x")
             default_int: int = config(long=True, default=3)
             store_true: bool = config(long=True, action="store_true")
-            nargs: list = config(long=True, nargs="+", type=int)
+            nargs: List[int] = config(long=True, nargs="+", type=int)
 
         set_args(
             "--long_arg",
@@ -56,10 +57,8 @@ class TestClassOpt(unittest.TestCase):
         del_args()
 
     def test_generic_alias(self):
-        from typing import List
-
         class Opt(ClassOpt):
-            list_a: list[int] = config(long=True, nargs="+")
+            list_a: List[int] = config(long=True, nargs="+")
             list_b: List[str] = config(long=True, nargs="*")
 
         set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")
@@ -73,7 +72,7 @@ class TestClassOpt(unittest.TestCase):
 
     def test_default_value(self):
         class Opt(ClassOpt):
-            numbers: list[int] = config(long=True)
+            numbers: List[int] = config(long=True)
             flag: bool = config(long=True)
 
         set_args("--numbers", "1", "2", "3", "--flag")


### PR DESCRIPTION
close #7 

I have set up CI to run unit test.

Through the process, I fixed type annotation in tests.
Some member variables are annotated as `list` but not `List` and this cause some tests [fail](https://github.com/ikanago/classopt/runs/7468539847?check_suite_focus=true).
I fixed `list` to `List` because the latter is used more often in the codebase.

I have selected OSs on which CI runs from [GitHub Actions documentation](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).
I chose the newer, but stable ones.
If you want to run CI on other OS, I'll reflect your choice.