### PR TITLE
Improve handling of default values

### DIFF
--- a/classopt/config.py
+++ b/classopt/config.py
@@ -1,4 +1,4 @@
-from dataclasses import field, Field
+from dataclasses import field, Field, MISSING
 from typing import Any, Optional, Union, Iterable, Tuple
 
 
@@ -35,7 +35,18 @@ def config(
     assign_if_not_none(metadata, "dest", dest)
     assign_if_not_none(metadata, "version", version)
 
-    return field(metadata=metadata)
+    # to avoid errors like below:
+    # ValueError: mutable default <class 'list'> for field hoge is not allowed: use default_factory
+    if isinstance(default, (list, dict, set)):
+        return field(
+            default_factory=lambda: default,
+            metadata=metadata,
+        )
+    else:
+        return field(
+            default=default,
+            metadata=metadata,
+        )
 
 
 def assign_if_not_none(d: dict, key: str, value: Any):

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -1,7 +1,7 @@
 import typing
 from typing import TYPE_CHECKING, overload
 from argparse import ArgumentParser
-from dataclasses import dataclass
+from dataclasses import dataclass, MISSING
 
 if TYPE_CHECKING:
     from typing import Literal, Callable, TypeVar, Type, Union, Generic
@@ -74,6 +74,11 @@ def _process_class(cls, default_long: bool, default_short: bool):
             elif arg_field.type == bool:
                 kwargs.pop("type")
                 kwargs["action"] = "store_true"
+
+            if arg_field.default != MISSING:
+                kwargs["default"] = arg_field.type(arg_field.default)
+            elif arg_field.default_factory != MISSING:
+                kwargs["default"] = arg_field.type(arg_field.default_factory())
 
             generic_aliases = [typing._GenericAlias]
             try:

--- a/examples/print_args.py
+++ b/examples/print_args.py
@@ -1,0 +1,15 @@
+from classopt import classopt, config
+from pathlib import Path
+
+@classopt(default_long=True, default_short=True)
+class Opt:
+    x: int
+    a: int = config(default=5)
+    b: int = 10
+    c: Path = "./tmp.txt"
+    d: list = config(default=[0, 1, 2], nargs="+", type=int)
+
+
+if __name__ == "__main__":
+    opt = Opt.from_args()
+    print(opt)

--- a/examples/print_args.py
+++ b/examples/print_args.py
@@ -3,13 +3,12 @@ from pathlib import Path
 
 @classopt(default_long=True, default_short=True)
 class Opt:
-    x: int
-    a: int = config(default=5)
-    b: int = 10
-    c: Path = "./tmp.txt"
+    a: int = 0
+    b: int = config(default=1)
+    c: Path = Path("./tmp.txt")
     d: list = config(default=[0, 1, 2], nargs="+", type=int)
 
 
 if __name__ == "__main__":
-    opt = Opt.from_args()
+    opt: Opt = Opt.from_args()
     print(opt)


### PR DESCRIPTION
The current version of classopt can't handle default values like dataclass as in the case of the code shown below.

```python:tmp.py
from classopt import classopt

@classopt(default_long=True, default_short=True)
class Opt:
    a: int = 0

if __name__ == "__main__":
    opt: Opt = Opt.from_args()
    print(opt)
```

The resulting value of `opt.a` will be `None`.

```bash
$ python tmp.py
Opt(a=None)
```

This PR allows classopt to handle such simple default values well.
This will improve usability for simple use cases that do not require the use of `config`.


After merging this PR, you will be able to handle default values such as the following code.

```python:tmp.py
from classopt import classopt, config
from pathlib import Path

@classopt(default_long=True, default_short=True)
class Opt:
    a: int = 0
    b: int = config(default=1)
    c: Path = Path("./tmp.txt")
    d: list = config(default=[0, 1, 2], nargs="+", type=int)

if __name__ == "__main__":
    opt: Opt = Opt.from_args()
    print(opt)
```

```bash
$ python tmp.py
Opt(a=0, b=1, c=PosixPath('tmp.txt'), d=[0, 1, 2])
```

This will be very useful for daily coding!
