### PR TITLE
Enable user-defined argument parsers

### DIFF
--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -29,9 +29,9 @@ def classopt(
 ) -> "Callable[[Type[_C]], Union[Type[_C], Type[_ClassOptGeneric[_C]]]]":
     ...
 
-def classopt(cls=None, default_long=False, default_short=False):
+def classopt(cls=None, default_long=False, default_short=False,parser=None):
     def wrap(cls):
-        return _process_class(cls, default_long, default_short)
+        return _process_class(cls, default_long, default_short, parser)
 
     if cls is None:
         return wrap
@@ -39,10 +39,11 @@ def classopt(cls=None, default_long=False, default_short=False):
     return wrap(cls)
 
 
-def _process_class(cls, default_long: bool, default_short: bool):
+def _process_class(cls, default_long: bool, default_short: bool, external_parser: ArgumentParser):
     @classmethod
     def from_args(cls):
-        parser = ArgumentParser()
+        # parser = ArgumentParser()
+        parser = external_parser if external_parser is not None else ArgumentParser()
 
         for arg_name, arg_field in cls.__dataclass_fields__.items():
             kwargs = {}

--- a/classopt/inheritance.py
+++ b/classopt/inheritance.py
@@ -8,8 +8,12 @@ T = TypeVar("T")
 
 class ClassOpt:
     @classmethod
+    def _parser_factory(cls: T) -> ArgumentParser:
+        return ArgumentParser()
+
+    @classmethod
     def from_args(cls: T) -> T:
-        parser = ArgumentParser()
+        parser = cls._parser_factory()
 
         for arg_name, arg_type in cls.__annotations__.items():
             kwargs = {}

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -94,7 +94,7 @@ class TestClassOpt(unittest.TestCase):
 
         @classopt(default_long=True)
         class Opt:
-            list_a: list[int] = config(nargs="+")
+            list_a: List[int] = config(nargs="+")
             list_b: List[str] = config(nargs="*")
 
         set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")
@@ -107,9 +107,10 @@ class TestClassOpt(unittest.TestCase):
         del_args()
 
     def test_default_value(self):
+        from typing import List
         @classopt(default_long=True)
         class Opt:
-            numbers: list[int]
+            numbers: List[int]
             flag: bool
 
         set_args("--numbers", "1", "2", "3", "--flag")

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -122,6 +122,39 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
+    def test_external_parser(self):
+        from argparse import ArgumentParser
+        class userArgumentParserException(Exception):
+            pass
+
+        class userArgumentParser(ArgumentParser):
+            def error(self,message):
+                raise userArgumentParserException()
+
+        @classopt(parser=userArgumentParser())
+        class Opt:
+            arg_int: int
+            arg_str: str
+            arg_float: float
+
+        set_args("5", "hello", "3.2")
+
+        opt = Opt.from_args()
+
+        assert opt.arg_int == 5
+        assert opt.arg_str == "hello"
+        assert opt.arg_float == 3.2
+
+        del_args()
+
+        set_args("5", "hello")
+
+        with self.assertRaises(userArgumentParserException):
+            opt = Opt.from_args()
+
+        del_args()
+
+
 
 def set_args(*args):
     del_args()  # otherwise tests fail with e.g. "pytest -s"

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -59,7 +59,7 @@ class TestClassOpt(unittest.TestCase):
         from typing import List
 
         class Opt(ClassOpt):
-            list_a: list[int] = config(long=True, nargs="+")
+            list_a: List[int] = config(long=True, nargs="+")
             list_b: List[str] = config(long=True, nargs="*")
 
         set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")
@@ -72,8 +72,9 @@ class TestClassOpt(unittest.TestCase):
         del_args()
 
     def test_default_value(self):
+        from typing import List
         class Opt(ClassOpt):
-            numbers: list[int] = config(long=True)
+            numbers: List[int] = config(long=True)
             flag: bool = config(long=True)
 
         set_args("--numbers", "1", "2", "3", "--flag")

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -86,6 +86,42 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
+    def test_external_parser(self):
+        from argparse import ArgumentParser
+        class userArgumentParserException(Exception):
+            pass
+
+        class userArgumentParser(ArgumentParser):
+            def error(self,message):
+                raise userArgumentParserException()
+
+        class Opt(ClassOpt):
+            arg_int: int
+            arg_str: str
+            arg_float: float
+
+            @classmethod
+            def _parser_factory(cls) -> ArgumentParser:
+                return userArgumentParser()
+
+        set_args("5", "hello", "3.2")
+
+        opt = Opt.from_args()
+
+        assert opt.arg_int == 5
+        assert opt.arg_str == "hello"
+        assert opt.arg_float == 3.2
+
+        del_args()
+
+        set_args("5", "hello")
+
+        with self.assertRaises(userArgumentParserException):
+            opt = Opt.from_args()
+
+        del_args()
+
+
 
 def set_args(*args):
     for arg in args:


### PR DESCRIPTION
The ArgumentParser module may have its error handling behavior customized by the user.

e.g.)  replacing usage print with full help print in case of the error:
(https://stackoverflow.com/questions/5943249/python-argparse-and-controlling-overriding-the-exit-status-code)

This PR makes it possible to use user-defined parsers that inherit from the ArgumentParser class.

decorater:
```
@classopt(parser=userArgumentParser())
class Opt:
    arg_int: int
    arg_str: str
    arg_float: float
```

inheritance:
```
class Opt(ClassOpt):
    arg_int: int
    arg_str: str
    arg_float: float

    @classmethod
    def _parser_factory(cls) -> ArgumentParser:
        return userArgumentParser()
```

Thank you for your wonderful tool.