### PR TITLE
Add support for passing arguments from within script

### DIFF
--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -1,7 +1,7 @@
 import typing
 from argparse import ArgumentParser
 from dataclasses import MISSING, Field, dataclass
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, overload, List
 
 from classopt import config
 
@@ -49,7 +49,7 @@ def _process_class(
     cls, default_long: bool, default_short: bool, external_parser: ArgumentParser
 ):
     @classmethod
-    def from_args(cls):
+    def from_args(cls, *args :List[str]):
         parser = external_parser if external_parser is not None else ArgumentParser()
 
         for arg_name, arg_field in cls.__dataclass_fields__.items():
@@ -112,8 +112,9 @@ def _process_class(
 
             parser.add_argument(*name_or_flags, **kwargs)
 
-        args = parser.parse_args()
-        return cls(**vars(args))
+        args_in = args if len(args) != 0 else None
+        ns  = parser.parse_args(args=args_in)
+        return cls(**vars(ns))
 
     for arg_name in cls.__annotations__.keys():
         if not hasattr(cls, arg_name):

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -49,7 +49,7 @@ def _process_class(
     cls, default_long: bool, default_short: bool, external_parser: ArgumentParser
 ):
     @classmethod
-    def from_args(cls, *args :List[str]):
+    def from_args(cls, *args: str):
         parser = external_parser if external_parser is not None else ArgumentParser()
 
         for arg_name, arg_field in cls.__dataclass_fields__.items():

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -41,7 +41,7 @@ def classopt(cls=None, default_long=False, default_short=False):
 
 def _process_class(cls, default_long: bool, default_short: bool):
     @classmethod
-    def from_args(cls):
+    def from_args(cls,*args):
         parser = ArgumentParser()
 
         for arg_name, arg_field in cls.__dataclass_fields__.items():
@@ -95,8 +95,9 @@ def _process_class(cls, default_long: bool, default_short: bool):
 
             parser.add_argument(*name_or_flags, **kwargs)
 
-        args = parser.parse_args()
-        return cls(**vars(args))
+        args_in = args if len(args) != 0 else None
+        ns = parser.parse_args(args=args_in)
+        return cls(**vars(ns))
 
     setattr(cls, "from_args", from_args)
 

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -1,7 +1,7 @@
 import typing
 from argparse import ArgumentParser
 from dataclasses import MISSING, Field, dataclass
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, overload, Optional, List
 
 from classopt import config
 
@@ -49,7 +49,7 @@ def _process_class(
     cls, default_long: bool, default_short: bool, external_parser: ArgumentParser
 ):
     @classmethod
-    def from_args(cls, *args: str):
+    def from_args(cls, args: Optional[List[str]] = None):
         parser = external_parser if external_parser is not None else ArgumentParser()
 
         for arg_name, arg_field in cls.__dataclass_fields__.items():
@@ -112,8 +112,7 @@ def _process_class(
 
             parser.add_argument(*name_or_flags, **kwargs)
 
-        args_in = args if len(args) != 0 else None
-        ns  = parser.parse_args(args=args_in)
+        ns  = parser.parse_args(args=args)
         return cls(**vars(ns))
 
     for arg_name in cls.__annotations__.keys():

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -1,7 +1,7 @@
 import typing
 from argparse import ArgumentParser
 from dataclasses import MISSING, Field, dataclass
-from typing import TYPE_CHECKING, overload, List
+from typing import TYPE_CHECKING, overload
 
 from classopt import config
 

--- a/classopt/inheritance.py
+++ b/classopt/inheritance.py
@@ -8,7 +8,7 @@ T = TypeVar("T")
 
 class ClassOpt:
     @classmethod
-    def from_args(cls: T) -> T:
+    def from_args(cls: T,*args) -> T:
         parser = ArgumentParser()
 
         for arg_name, arg_type in cls.__annotations__.items():
@@ -60,6 +60,7 @@ class ClassOpt:
 
             parser.add_argument(*name_or_flags, **kwargs)
 
-        args = parser.parse_args()
+        args_in = args if len(args) != 0 else None
+        ns = parser.parse_args(args=args_in)
 
-        return dataclass(cls)(**vars(args))
+        return dataclass(cls)(**vars(ns))

--- a/classopt/inheritance.py
+++ b/classopt/inheritance.py
@@ -12,7 +12,7 @@ class ClassOpt:
         return ArgumentParser()
 
     @classmethod
-    def from_args(cls: T, *args: List[str] ) -> T:
+    def from_args(cls: T, *args: str) -> T:
         parser = cls._parser_factory()
 
         for arg_name, arg_type in cls.__annotations__.items():

--- a/classopt/inheritance.py
+++ b/classopt/inheritance.py
@@ -1,7 +1,7 @@
 import typing
 from argparse import ArgumentParser
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import TypeVar, List
 
 T = TypeVar("T")
 
@@ -12,7 +12,7 @@ class ClassOpt:
         return ArgumentParser()
 
     @classmethod
-    def from_args(cls: T) -> T:
+    def from_args(cls: T, *args: List[str] ) -> T:
         parser = cls._parser_factory()
 
         for arg_name, arg_type in cls.__annotations__.items():
@@ -64,6 +64,7 @@ class ClassOpt:
 
             parser.add_argument(*name_or_flags, **kwargs)
 
-        args = parser.parse_args()
+        args_in = args if len(args) != 0 else None
+        ns = parser.parse_args(args=args_in)
 
-        return dataclass(cls)(**vars(args))
+        return dataclass(cls)(**vars(ns))

--- a/classopt/inheritance.py
+++ b/classopt/inheritance.py
@@ -1,10 +1,9 @@
 import typing
 from argparse import ArgumentParser
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import TypeVar, Optional, List
 
 T = TypeVar("T")
-
 
 class ClassOpt:
     @classmethod
@@ -12,7 +11,7 @@ class ClassOpt:
         return ArgumentParser()
 
     @classmethod
-    def from_args(cls: T, *args: str) -> T:
+    def from_args(cls: T, args: Optional[List[str]] = None) -> T:
         parser = cls._parser_factory()
 
         for arg_name, arg_type in cls.__annotations__.items():
@@ -64,7 +63,6 @@ class ClassOpt:
 
             parser.add_argument(*name_or_flags, **kwargs)
 
-        args_in = args if len(args) != 0 else None
-        ns = parser.parse_args(args=args_in)
+        ns = parser.parse_args(args=args)
 
         return dataclass(cls)(**vars(ns))

--- a/classopt/inheritance.py
+++ b/classopt/inheritance.py
@@ -1,7 +1,7 @@
 import typing
 from argparse import ArgumentParser
 from dataclasses import dataclass
-from typing import TypeVar, List
+from typing import TypeVar
 
 T = TypeVar("T")
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -226,7 +226,7 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
-        opt2 = Opt.from_args("5","hello","3.2")
+        opt2 = Opt.from_args(["5","hello","3.2"])
 
         assert opt1.arg_int == opt2.arg_int
         assert opt1.arg_str == opt2.arg_str

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -212,6 +212,25 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg0 == Path("test.py")
 
         del_args()
+    
+    def test_args_from_scipt(self):
+        @classopt
+        class Opt:
+            arg_int: int
+            arg_str: str
+            arg_float: float
+
+        set_args("5", "hello", "3.2")
+
+        opt1 = Opt.from_args()
+
+        del_args()
+
+        opt2 = Opt.from_args("5","hello","3.2")
+
+        assert opt1.arg_int == opt2.arg_int
+        assert opt1.arg_str == opt2.arg_str
+        assert opt1.arg_float == opt2.arg_float
 
 
 def set_args(*args):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -121,6 +121,26 @@ class TestClassOpt(unittest.TestCase):
         assert opt.flag
 
         del_args()
+    
+    def test_interactive_prompt(self):
+        @classopt
+        class Opt:
+            arg_int: int
+            arg_str: str
+            arg_float: float
+
+        set_args("5", "hello", "3.2")
+
+        opt1 = Opt.from_args()
+
+        del_args()
+
+        opt2 = Opt.from_args("5","hello","3.2")
+
+        assert opt1.arg_int == opt2.arg_int
+        assert opt1.arg_str == opt2.arg_str
+        assert opt1.arg_float == opt2.arg_float
+
 
 
 def set_args(*args):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -142,26 +142,6 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
     
-    def test_interactive_prompt(self):
-        @classopt
-        class Opt:
-            arg_int: int
-            arg_str: str
-            arg_float: float
-
-        set_args("5", "hello", "3.2")
-
-        opt1 = Opt.from_args()
-
-        del_args()
-
-        opt2 = Opt.from_args("5","hello","3.2")
-
-        assert opt1.arg_int == opt2.arg_int
-        assert opt1.arg_str == opt2.arg_str
-        assert opt1.arg_float == opt2.arg_float
-
-
     def test_external_parser(self):
         from argparse import ArgumentParser
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -94,7 +94,7 @@ class TestClassOpt(unittest.TestCase):
 
         @classopt(default_long=True)
         class Opt:
-            list_a: list[int] = config(nargs="+")
+            list_a: List[int] = config(nargs="+")
             list_b: List[str] = config(nargs="*")
 
         set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")
@@ -107,9 +107,10 @@ class TestClassOpt(unittest.TestCase):
         del_args()
 
     def test_default_value(self):
+        from typing import List
         @classopt(default_long=True)
         class Opt:
-            numbers: list[int]
+            numbers: List[int]
             flag: bool
 
         set_args("--numbers", "1", "2", "3", "--flag")

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -86,24 +86,6 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
-    def test_interactive_prompt(self):
-        class Opt(ClassOpt):
-            arg_int: int
-            arg_str: str
-            arg_float: float
-        set_args("5", "hello", "3.2")
-
-        opt1 = Opt.from_args()
-
-        del_args()
-
-        opt2 = Opt.from_args("5","hello","3.2")
-
-        assert opt1.arg_int == opt2.arg_int
-        assert opt1.arg_str == opt2.arg_str
-        assert opt1.arg_float == opt2.arg_float
-
-
     def test_external_parser(self):
         from argparse import ArgumentParser
 

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -59,7 +59,7 @@ class TestClassOpt(unittest.TestCase):
         from typing import List
 
         class Opt(ClassOpt):
-            list_a: list[int] = config(long=True, nargs="+")
+            list_a: List[int] = config(long=True, nargs="+")
             list_b: List[str] = config(long=True, nargs="*")
 
         set_args("--list_a", "3", "2", "1", "--list_b", "hello", "world")
@@ -72,8 +72,9 @@ class TestClassOpt(unittest.TestCase):
         del_args()
 
     def test_default_value(self):
+        from typing import List
         class Opt(ClassOpt):
-            numbers: list[int] = config(long=True)
+            numbers: List[int] = config(long=True)
             flag: bool = config(long=True)
 
         set_args("--numbers", "1", "2", "3", "--flag")

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -121,6 +121,26 @@ class TestClassOpt(unittest.TestCase):
             opt = Opt.from_args()
 
         del_args()
+    
+    def test_args_from_script(self):
+        class Opt(ClassOpt):
+            arg_int: int
+            arg_str: str
+            arg_float: float
+
+        set_args("5", "hello", "3.2")
+
+        opt1 = Opt.from_args()
+
+        del_args()
+
+        opt2 = Opt.from_args("5","hello","3.2")
+
+        assert opt1.arg_int == opt2.arg_int
+        assert opt1.arg_str == opt2.arg_str
+        assert opt1.arg_float == opt2.arg_float
+
+
 
 
 def set_args(*args):

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -86,6 +86,24 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
+    def test_interactive_prompt(self):
+        class Opt(ClassOpt):
+            arg_int: int
+            arg_str: str
+            arg_float: float
+
+        set_args("5", "hello", "3.2")
+
+        opt1 = Opt.from_args()
+
+        del_args()
+
+        opt2 = Opt.from_args("5","hello","3.2")
+
+        assert opt1.arg_int == opt2.arg_int
+        assert opt1.arg_str == opt2.arg_str
+        assert opt1.arg_float == opt2.arg_float
+
 
 def set_args(*args):
     for arg in args:

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -134,7 +134,7 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
-        opt2 = Opt.from_args("5","hello","3.2")
+        opt2 = Opt.from_args(["5","hello","3.2"])
 
         assert opt1.arg_int == opt2.arg_int
         assert opt1.arg_str == opt2.arg_str


### PR DESCRIPTION
Thank you for your wonderful tool.

According to the [documentation](https://docs.python.org/3/library/argparse.html), argparse can also parse arguments other than those of sys.argv.

> Sometimes it may be useful to have an ArgumentParser parse arguments other than those of sys.argv
> This can be accomplished by passing a list of strings to parse_args().
> This is useful for testing at the interactive prompt:

An example of where this implementation would be useful in my opinion is:
An application that can be started by double-clicking a .py file and then inputting various arguments according to the console instructions.

This PR makes it possible to give arguments from within the python script as well as the command line arguments

usage:

```
# Parse command line arguments (sys.argv)
opt1 = Opt.from_args()

# Parse arguments given from within the script
opt2 = Opt.from_args("5","hello","3.2")
```
