### PR TITLE
Add interconversion with dict

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         os: ["ubuntu-20.04", "macos-12", "windows-2022"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -1,7 +1,7 @@
 import typing
 from argparse import ArgumentParser
-from dataclasses import MISSING, Field, dataclass
-from typing import TYPE_CHECKING, overload, Optional, List
+from dataclasses import MISSING, Field, dataclass, asdict
+from typing import TYPE_CHECKING, List, Optional, overload
 
 from classopt import config
 
@@ -14,6 +14,13 @@ if TYPE_CHECKING:
     class _ClassOptGeneric(Generic[_T]):
         @classmethod
         def from_args(cls) -> _T:
+            ...
+
+        def to_dict(self) -> dict:
+            ...
+
+        @classmethod
+        def from_dict(cls, data: dict) -> _T:
             ...
 
 
@@ -112,7 +119,7 @@ def _process_class(
 
             parser.add_argument(*name_or_flags, **kwargs)
 
-        ns  = parser.parse_args(args=args)
+        ns = parser.parse_args(args=args)
         return cls(**vars(ns))
 
     for arg_name in cls.__annotations__.keys():
@@ -122,5 +129,16 @@ def _process_class(
             setattr(cls, arg_name, config(default=getattr(cls, arg_name)))
 
     setattr(cls, "from_args", from_args)
+
+    def to_dict(self):
+        return asdict(self)
+
+    setattr(cls, "to_dict", to_dict)
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(**data)
+
+    setattr(cls, "from_dict", from_dict)
 
     return dataclass(cls)

--- a/classopt/inheritance.py
+++ b/classopt/inheritance.py
@@ -5,6 +5,7 @@ from typing import TypeVar, Optional, List
 
 T = TypeVar("T")
 
+
 class ClassOpt:
     @classmethod
     def _parser_factory(cls: T) -> ArgumentParser:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -141,7 +141,7 @@ class TestClassOpt(unittest.TestCase):
         assert opt.flag
 
         del_args()
-    
+
     def test_external_parser(self):
         from argparse import ArgumentParser
 
@@ -212,7 +212,7 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg0 == Path("test.py")
 
         del_args()
-    
+
     def test_args_from_scipt(self):
         @classopt
         class Opt:
@@ -226,11 +226,68 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
-        opt2 = Opt.from_args(["5","hello","3.2"])
+        opt2 = Opt.from_args(["5", "hello", "3.2"])
 
         assert opt1.arg_int == opt2.arg_int
         assert opt1.arg_str == opt2.arg_str
         assert opt1.arg_float == opt2.arg_float
+
+    def test_to_dict(self):
+        from pathlib import Path
+        from typing import List
+
+        @classopt
+        class Opt:
+            arg_int: int
+            arg_float: float
+            arg_path: Path
+            arg_list: List[str]
+
+        set_args("3", "3.2", "test.txt", "a", "b", "c")
+
+        opt = Opt.from_args()
+
+        opt_dict = opt.to_dict()
+        correct_dict = {
+            "arg_int": 3,
+            "arg_float": 3.2,
+            "arg_path": Path("test.txt"),
+            "arg_list": ["a", "b", "c"],
+        }
+
+        assert all(
+            opt_dict[key] == correct_dict[key]
+            for key in set(list(opt_dict.keys()) + list(correct_dict.keys()))
+        )
+
+        del_args()
+
+    def test_from_dict(self):
+        from pathlib import Path
+        from typing import List
+
+        @classopt
+        class Opt:
+            arg_int: int
+            arg_float: float
+            arg_path: Path
+            arg_list: List[str]
+
+        args_dict = {
+            "arg_int": 3,
+            "arg_float": 3.2,
+            "arg_path": Path("test.txt"),
+            "arg_list": ["a", "b", "c"],
+        }
+
+        opt = Opt.from_dict(args_dict)
+
+        assert opt.arg_int == args_dict["arg_int"]
+        assert opt.arg_float == args_dict["arg_float"]
+        assert opt.arg_path == args_dict["arg_path"]
+        assert opt.arg_list == args_dict["arg_list"]
+
+        del_args()
 
 
 def set_args(*args):


### PR DESCRIPTION
Add the methods `to_dict` and `from_dict` to the argument instance for interconversion with dict.

### to_dict
```python
from classopt import classopt

@classopt
class Opt:
    arg: int

opt = Opt.from_args()
print(opt.to_dict())
```
```bash
$ python example.py 3
{'arg': 3}
```

### from_dict
```python
from classopt import classopt

@classopt
class Opt:
    arg: int

args_dict = {"arg": 3}
opt = Opt.from_dict(args_dict)
print(opt)
```
```bash
Opt(arg=3)
```