### PR TITLE
Improve tests and the behavior of `from_dict`

### DIFF
--- a/classopt/decorator.py
+++ b/classopt/decorator.py
@@ -57,9 +57,7 @@ def classopt(cls=None, default_long=False, default_short=False, parser=None):
     return wrap(cls)
 
 
-def _process_class(
-    cls, default_long: bool, default_short: bool, external_parser: ArgumentParser
-):
+def _process_class(cls, default_long: bool, default_short: bool, external_parser: ArgumentParser):
     @classmethod
     def from_args(cls, args: Optional[List[str]] = None):
         parser = external_parser if external_parser is not None else ArgumentParser()
@@ -104,10 +102,7 @@ def _process_class(
             elif arg_field.default_factory != MISSING:
                 kwargs["default"] = arg_field.type(arg_field.default_factory())
 
-            if (
-                type(arg_field.type) in GENERIC_ALIASES
-                and arg_field.type.__origin__ == list
-            ):
+            if type(arg_field.type) in GENERIC_ALIASES and arg_field.type.__origin__ == list:
                 kwargs["type"] = arg_field.type.__args__[0]
                 if not "nargs" in arg_field.metadata:
                     kwargs["nargs"] = "*"
@@ -130,9 +125,7 @@ def _process_class(
 
     def to_dict(self):
         def classopt_dict_factory(items: List[Tuple[str, Any]]) -> Dict[str, Any]:
-            converted_dict = {
-                key: convert_non_primitives_to_string(value) for key, value in items
-            }
+            converted_dict = {key: convert_non_primitives_to_string(value) for key, value in items}
 
             return converted_dict
 
@@ -143,14 +136,26 @@ def _process_class(
     @classmethod
     def from_dict(cls, data: dict):
         reverted_data = {
-            key: revert_non_primitives_from_string(
-                value, original_type=cls.__annotations__[key]
-            )
+            key: revert_non_primitives_from_string(value, original_type=cls.__annotations__[key])
             for key, value in data.items()
             if key in cls.__annotations__
         }
 
-        return cls(**reverted_data)
+        default_data = {}
+        for arg_name, arg_field in cls.__dataclass_fields__.items():
+            if arg_name in reverted_data:
+                continue
+            if (
+                arg_field.default == MISSING and arg_field.default_factory == MISSING
+            ) or arg_field.default is None:
+                default_data[arg_name] = None
+            elif arg_field.default != MISSING:
+                default_data[arg_name] = arg_field.type(arg_field.default)
+            elif arg_field.default_factory != MISSING:
+                type_ = arg_field.type.__origin__
+                default_data[arg_name] = type_(arg_field.default_factory())
+
+        return cls(**default_data, **reverted_data)
 
     setattr(cls, "from_dict", from_dict)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import sys
+
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_args():
+    # Cleanup args before each test
+    # otherwise tests fail with e.g. "pytest -s" because sys.argv[1:] becomes ["-s"]
+    # and pytest options will be parsed by `ArgumentParser`
+    del_args()
+
+    # Run a test...
+    yield
+
+    # Cleanup args after each test
+    del_args()
+
+
+def set_args(*args):
+    del_args()
+    for arg in args:
+        sys.argv.append(arg)
+
+
+def del_args():
+    del sys.argv[1:]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -6,6 +6,8 @@ import pytest
 
 from classopt import classopt, config
 
+from .conftest import del_args, set_args
+
 
 class TestClassOpt(unittest.TestCase):
     def test_classopt(self):
@@ -22,8 +24,6 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg_int == 5
         assert opt.arg_str == "hello"
         assert opt.arg_float == 3.2
-
-        del_args()
 
     def test_advanced_usage(self):
         @classopt()
@@ -58,8 +58,6 @@ class TestClassOpt(unittest.TestCase):
         assert opt.store_true
         assert opt.nargs == [1, 2, 3]
 
-        del_args()
-
     def test_default_long(self):
         @classopt(default_long=True)
         class Opt:
@@ -75,8 +73,6 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg1 == 3
         assert opt.arg2 == "hello"
 
-        del_args()
-
     def test_default_short(self):
         @classopt(default_long=True, default_short=True)
         class Opt:
@@ -90,8 +86,6 @@ class TestClassOpt(unittest.TestCase):
         assert opt.a_arg == 3
         assert opt.b_arg == "hello"
 
-        del_args()
-
     def test_generic_alias(self):
         @classopt(default_long=True)
         class Opt:
@@ -104,8 +98,6 @@ class TestClassOpt(unittest.TestCase):
 
         assert opt.list_a == [3, 2, 1]
         assert opt.list_b == ["hello", "world"]
-
-        del_args()
 
     @pytest.mark.skipif(
         sys.version_info < (3, 9),
@@ -124,11 +116,7 @@ class TestClassOpt(unittest.TestCase):
         assert opt.list_a == [3, 2, 1]
         assert opt.list_b == ["hello", "world"]
 
-        del_args()
-
     def test_default_value(self):
-        from typing import List
-
         @classopt(default_long=True)
         class Opt:
             numbers: List[int]
@@ -140,8 +128,6 @@ class TestClassOpt(unittest.TestCase):
 
         assert opt.numbers == [1, 2, 3]
         assert opt.flag
-
-        del_args()
 
     def test_external_parser(self):
         from argparse import ArgumentParser
@@ -167,14 +153,10 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg_str == "hello"
         assert opt.arg_float == 3.2
 
-        del_args()
-
         set_args("5", "hello")
 
         with self.assertRaises(userArgumentParserException):
             opt = Opt.from_args()
-
-        del_args()
 
     def test_simple_default_value_passing(self):
         @classopt(default_long=True)
@@ -197,8 +179,6 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg4 == [1, 2, 3]
         assert opt.arg5 == "hello"
 
-        del_args()
-
     def test_convert_default_value_type_to_specified_type(self):
         from pathlib import Path
 
@@ -211,8 +191,6 @@ class TestClassOpt(unittest.TestCase):
         opt = Opt.from_args()
 
         assert opt.arg0 == Path("test.py")
-
-        del_args()
 
     def test_args_from_scipt(self):
         @classopt
@@ -261,8 +239,6 @@ class TestClassOpt(unittest.TestCase):
             for key in set(list(opt_dict.keys()) + list(correct_dict.keys()))
         )
 
-        del_args()
-
     def test_from_dict(self):
         from pathlib import Path
         from typing import List
@@ -288,14 +264,30 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg_path == Path(args_dict["arg_path"])
         assert opt.arg_list == args_dict["arg_list"]
 
-        del_args()
+    def test_from_dict_partial(self):
+        from pathlib import Path
+        from typing import List, Set
 
+        @classopt
+        class Opt:
+            arg_int: int
+            arg_float: float = 0.0
+            arg_str: str = "test"
+            arg_path: Path = "test.txt"
+            arg_list: List[str] = ["a", "b"]
+            # test for implicit type conversion
+            arg_set: Set[str] = ["a", "b"]
 
-def set_args(*args):
-    del_args()  # otherwise tests fail with e.g. "pytest -s"
-    for arg in args:
-        sys.argv.append(arg)
+        args_dict = {
+            "arg_int": 3,
+            "arg_float": 3.2,
+        }
 
+        opt = Opt.from_dict(args_dict)
 
-def del_args():
-    del sys.argv[1:]
+        assert opt.arg_int == args_dict["arg_int"]
+        assert opt.arg_float == args_dict["arg_float"]
+        assert opt.arg_str == "test"
+        assert opt.arg_path == Path("test.txt")
+        assert opt.arg_list == ["a", "b"]
+        assert opt.arg_set == {"a", "b"}

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,8 +1,9 @@
-import sys
 import unittest
 from typing import List
 
 from classopt import ClassOpt, config
+
+from .conftest import del_args, set_args
 
 
 class TestClassOpt(unittest.TestCase):
@@ -19,8 +20,6 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg_int == 5
         assert opt.arg_str == "hello"
         assert opt.arg_float == 3.2
-
-        del_args()
 
     def test_advanced_usage(self):
         class Opt(ClassOpt):
@@ -54,8 +53,6 @@ class TestClassOpt(unittest.TestCase):
         assert opt.store_true
         assert opt.nargs == [1, 2, 3]
 
-        del_args()
-
     def test_generic_alias(self):
         class Opt(ClassOpt):
             list_a: List[int] = config(long=True, nargs="+")
@@ -68,11 +65,7 @@ class TestClassOpt(unittest.TestCase):
         assert opt.list_a == [3, 2, 1]
         assert opt.list_b == ["hello", "world"]
 
-        del_args()
-
     def test_default_value(self):
-        from typing import List
-
         class Opt(ClassOpt):
             numbers: List[int] = config(long=True)
             flag: bool = config(long=True)
@@ -83,8 +76,6 @@ class TestClassOpt(unittest.TestCase):
 
         assert opt.numbers == [1, 2, 3]
         assert opt.flag
-
-        del_args()
 
     def test_external_parser(self):
         from argparse import ArgumentParser
@@ -113,15 +104,11 @@ class TestClassOpt(unittest.TestCase):
         assert opt.arg_str == "hello"
         assert opt.arg_float == 3.2
 
-        del_args()
-
         set_args("5", "hello")
 
         with self.assertRaises(userArgumentParserException):
             opt = Opt.from_args()
 
-        del_args()
-    
     def test_args_from_script(self):
         class Opt(ClassOpt):
             arg_int: int
@@ -134,18 +121,8 @@ class TestClassOpt(unittest.TestCase):
 
         del_args()
 
-        opt2 = Opt.from_args(["5","hello","3.2"])
+        opt2 = Opt.from_args(["5", "hello", "3.2"])
 
         assert opt1.arg_int == opt2.arg_int
         assert opt1.arg_str == opt2.arg_str
         assert opt1.arg_float == opt2.arg_float
-
-
-
-def set_args(*args):
-    for arg in args:
-        sys.argv.append(arg)
-
-
-def del_args():
-    del sys.argv[1:]


### PR DESCRIPTION
`from_dict` of the current version behaves differently in implicit type conversion.

For example,

```python
class Opt:
  hoge: Path = "hoge"
  fuga: int = 5

opt = Opt.from_dict({"fuga": 10})
type(opt.hoge)
```
In this code, type(opt.hoge) is supposed to be of type `Path`, but it is actually `str`.
This PR modifies the behavior so that `from_dict` is more consistent with `from_args`.

In addition, improve the readability of tests by writing the common process in `conftest.py`.
Now, thanks to Fixtures of pytest, `del_args` is automatically executed in each test.
